### PR TITLE
make brewlib .net5+ compatible

### DIFF
--- a/Graphics/DrawState.cs
+++ b/Graphics/DrawState.cs
@@ -432,7 +432,6 @@ namespace BrewLib.Graphics
 
         private static void retrieveRendererInfo()
         {
-            logVideoControllers();
             CheckError("initializing");
 
             var openGlVersionString = GL.GetString(StringName.Version);
@@ -524,31 +523,6 @@ namespace BrewLib.Graphics
                 throw new Exception(
                     (context != null ? "openGL error while " + context : "openGL error") +
                     (error != ErrorCode.NoError ? ": " + error.ToString() : string.Empty));
-        }
-
-        private static void logVideoControllers()
-        {
-            try
-            {
-                // https://msdn.microsoft.com/en-us/library/aa394512(v=vs.85).aspx
-                var searcher = new ManagementObjectSearcher("select * from Win32_VideoController");
-
-                Trace.WriteLine("");
-                Trace.WriteLine("Video controllers:\n");
-                foreach (var o in searcher.Get())
-                {
-                    Trace.WriteLine(o["Name"]);
-                    Trace.WriteLine($"Status: {o["Status"]}, Availability: {o["Availability"]}, ConfigManagerErrorCode: {o["ConfigManagerErrorCode"]}");
-                    Trace.WriteLine($"DriverVersion: {o["DriverVersion"]}, DriverDate: {o["DriverDate"]}, InstalledDisplayDrivers: {o["InstalledDisplayDrivers"]}");
-                    Trace.WriteLine($"VideoProcessor: {o["VideoProcessor"]}, VideoArchitecture: {o["VideoArchitecture"]}, VideoMemoryType: {o["VideoMemoryType"]}, CurrentBitsPerPixel: {o["CurrentBitsPerPixel"]}");
-                    Trace.WriteLine($"AdapterDACType: {o["AdapterDACType"]}, AdapterRAM: {o["AdapterRAM"]}");
-                    Trace.WriteLine("");
-                }
-            }
-            catch (Exception e)
-            {
-                Trace.WriteLine($"Failed to retrieve video controller information: {e}");
-            }
         }
 
         #endregion

--- a/Graphics/Renderers/PrimitiveStreamers/PrimitiveStreamerPersistentMap.cs
+++ b/Graphics/Renderers/PrimitiveStreamers/PrimitiveStreamerPersistentMap.cs
@@ -13,7 +13,7 @@ namespace BrewLib.Graphics.Renderers.PrimitiveStreamers
     /// [include requirements for GpuCommandSync]
     /// [include requirements for PrimitiveStreamerVao]
     /// </summary>
-    public class PrimitiveStreamerPersistentMap<TPrimitive> : PrimitiveStreamerVao<TPrimitive>, PrimitiveStreamer<TPrimitive> 
+    public class PrimitiveStreamerPersistentMap<TPrimitive> : PrimitiveStreamerVao<TPrimitive>, PrimitiveStreamer<TPrimitive>
         where TPrimitive : struct
     {
         private GpuCommandSync commandSync;
@@ -79,7 +79,10 @@ namespace BrewLib.Graphics.Renderers.PrimitiveStreamers
             var pinnedVertexData = GCHandle.Alloc(primitives, GCHandleType.Pinned);
             try
             {
-                Native.CopyMemory(bufferPointer + bufferOffset, pinnedVertexData.AddrOfPinnedObject(), (uint)vertexDataSize);
+                if (Environment.Version.Major >= 5) /* .NET 5+ */
+                    Native.RtlMoveMemory(bufferPointer + bufferOffset, pinnedVertexData.AddrOfPinnedObject(), (uint)vertexDataSize);
+                else /* <= .NET 4.X */
+                    Native.CopyMemory(bufferPointer + bufferOffset, pinnedVertexData.AddrOfPinnedObject(), (uint)vertexDataSize);
             }
             finally
             {

--- a/Graphics/Renderers/PrimitiveStreamers/PrimitiveStreamerPersistentMap.cs
+++ b/Graphics/Renderers/PrimitiveStreamers/PrimitiveStreamerPersistentMap.cs
@@ -80,7 +80,7 @@ namespace BrewLib.Graphics.Renderers.PrimitiveStreamers
             try
             {
                 if (Environment.Version.Major >= 5) /* .NET 5+ */
-                    Native.RtlMoveMemory(bufferPointer + bufferOffset, pinnedVertexData.AddrOfPinnedObject(), (uint)vertexDataSize);
+                    Native.RtlCopyMemory(bufferPointer + bufferOffset, pinnedVertexData.AddrOfPinnedObject(), (uint)vertexDataSize);
                 else /* <= .NET 4.X */
                     Native.CopyMemory(bufferPointer + bufferOffset, pinnedVertexData.AddrOfPinnedObject(), (uint)vertexDataSize);
             }

--- a/Util/Native.cs
+++ b/Util/Native.cs
@@ -11,8 +11,8 @@ namespace BrewLib.Util
         [DllImport("kernel32.dll", EntryPoint = "CopyMemory", SetLastError = false)]
         public static extern void CopyMemory(IntPtr dest, IntPtr src, uint count); /* <= .NET 4.X */
 
-        [DllImport("kernel32.dll", EntryPoint = "RtlMoveMemory", SetLastError = false)]
-        public static extern void RtlMoveMemory(IntPtr dest, IntPtr src, uint count); /* .NET 5+ */
+        [DllImport("kernel32.dll", EntryPoint = "RtlCopyMemory", SetLastError = false)]
+        public static extern void RtlCopyMemory(IntPtr dest, IntPtr src, uint count); /* .NET 5+ */
 
         [DllImport("user32.dll")]
         public static extern void SwitchToThisWindow(IntPtr hWnd, bool fAltTab);

--- a/Util/Native.cs
+++ b/Util/Native.cs
@@ -9,7 +9,10 @@ namespace BrewLib.Util
     public static class Native
     {
         [DllImport("kernel32.dll", EntryPoint = "CopyMemory", SetLastError = false)]
-        public static extern void CopyMemory(IntPtr dest, IntPtr src, uint count);
+        public static extern void CopyMemory(IntPtr dest, IntPtr src, uint count); /* <= .NET 4.X */
+
+        [DllImport("kernel32.dll", EntryPoint = "RtlMoveMemory", SetLastError = false)]
+        public static extern void RtlMoveMemory(IntPtr dest, IntPtr src, uint count); /* .NET 5+ */
 
         [DllImport("user32.dll")]
         public static extern void SwitchToThisWindow(IntPtr hWnd, bool fAltTab);


### PR DESCRIPTION
This ensures that brewlib, which still runs on .net 4.5.2, is compatible wtih https://github.com/Damnae/storybrew/pull/77.

This includes two changes:
1. Instead of `CopyMemory`, `RtlCopyMemory` is used on .NET 5+
2. I opted to remove the video controller logging, because I just couldn't get the `System.Management` package to reference properly when this 4.5.2 library is used from .net 5+